### PR TITLE
Set ProcessDefinitionQueryDto.java attributes as protected.

### DIFF
--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/repository/ProcessDefinitionQueryDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/repository/ProcessDefinitionQueryDto.java
@@ -58,36 +58,36 @@ public class ProcessDefinitionQueryDto extends AbstractQueryDto<ProcessDefinitio
     VALID_SORT_BY_VALUES.add(SORT_BY_VERSION_TAG);
   }
 
-  private String processDefinitionId;
-  private List<String> processDefinitionIdIn;
-  private String category;
-  private String categoryLike;
-  private String name;
-  private String nameLike;
-  private String deploymentId;
-  private String key;
-  private String keyLike;
-  private Integer version;
-  private Boolean latestVersion;
-  private String resourceName;
-  private String resourceNameLike;
-  private String startableBy;
-  private Boolean active;
-  private Boolean suspended;
-  private String incidentId;
-  private String incidentType;
-  private String incidentMessage;
-  private String incidentMessageLike;
-  private List<String> tenantIds;
-  private Boolean withoutTenantId;
-  private Boolean includeDefinitionsWithoutTenantId;
-  private String versionTag;
-  private String versionTagLike;
-  private Boolean withoutVersionTag;
-  private List<String> keys;
-  private Boolean startableInTasklist;
-  private Boolean notStartableInTasklist;
-  private Boolean startablePermissionCheck;
+  protected String processDefinitionId;
+  protected List<String> processDefinitionIdIn;
+  protected String category;
+  protected String categoryLike;
+  protected String name;
+  protected String nameLike;
+  protected String deploymentId;
+  protected String key;
+  protected String keyLike;
+  protected Integer version;
+  protected Boolean latestVersion;
+  protected String resourceName;
+  protected String resourceNameLike;
+  protected String startableBy;
+  protected Boolean active;
+  protected Boolean suspended;
+  protected String incidentId;
+  protected String incidentType;
+  protected String incidentMessage;
+  protected String incidentMessageLike;
+  protected List<String> tenantIds;
+  protected Boolean withoutTenantId;
+  protected Boolean includeDefinitionsWithoutTenantId;
+  protected String versionTag;
+  protected String versionTagLike;
+  protected Boolean withoutVersionTag;
+  protected List<String> keys;
+  protected Boolean startableInTasklist;
+  protected Boolean notStartableInTasklist;
+  protected Boolean startablePermissionCheck;
 
   public ProcessDefinitionQueryDto() {
 


### PR DESCRIPTION
Allow for extensibility similar to org.camunda.bpm.engine.rest.dto.runtime.modification.ProcessInstanceModificationInstructionDto, org.camunda.bpm.engine.rest.dto.runtime.StartProcessInstanceDto and many others.

Some uses are builders extending the class to either allow full configuration or setting user selected defaults, facades, factories or integrations with search engines that need to create custom queries programmatically.